### PR TITLE
Fix RuboCop offense, add missing package

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -34,7 +34,7 @@ if platform_family?('rhel')
     fail ArgumentError, "Unknown value '#{node['nginx']['repo_source']}' was passed to the nginx cookbook."
   end
 elsif platform_family?('debian')
-  include_recipe 'nginx::repo-passenger' if node['nginx']['repo_source'] == 'passenger'
+  include_recipe 'nginx::repo_passenger' if node['nginx']['repo_source'] == 'passenger'
   include_recipe 'nginx::repo'           if node['nginx']['repo_source'] == 'nginx'
 end
 

--- a/recipes/repo_passenger.rb
+++ b/recipes/repo_passenger.rb
@@ -1,5 +1,5 @@
 # Cookbook Name:: nginx
-# Recipe:: repo-passenger
+# Recipe:: repo_passenger
 # Author:: Jose Alberto Suarez Lopez <ja@josealberto.org>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@ when 'rhel', 'fedora'
 when 'debian'
   include_recipe 'apt::default'
   package 'apt-transport-https'
+  package 'ca-certificates'
 
   apt_repository 'phusionpassenger' do
     uri 'https://oss-binaries.phusionpassenger.com/apt/passenger'


### PR DESCRIPTION
Should make https://github.com/miketheman/nginx/pull/321 green and adds the missing package.
